### PR TITLE
fix bug where simulator can modify the beam instance

### DIFF
--- a/croissant/simulator.py
+++ b/croissant/simulator.py
@@ -1,6 +1,7 @@
 from astropy import units
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
+from copy import deepcopy
 import matplotlib.pyplot as plt
 import numpy as np
 import warnings
@@ -60,13 +61,14 @@ class Simulator:
                 dt = np.linspace(0, total_time, N_times)
         self.dt = dt
         self.N_times = N_times
-        if beam.alm is None:
+        sim_beam = deepcopy(beam)
+        if sim_beam.alm is None:
             # apply horizon mask and initialize beam
-            beam.horizon_cut(horizon=horizon)
-            self.beam = beam
+            sim_beam.horizon_cut(horizon=horizon)
+            self.beam = sim_beam
             self.beam_alm()  # compute alms in ra/dec
         else:
-            self.beam = beam
+            self.beam = sim_beam
         # initialize sky
         self.sky = Alm.from_healpix(sky, lmax=self.lmax)
         if self.sky.coords != "equatorial":

--- a/croissant/simulator.py
+++ b/croissant/simulator.py
@@ -103,9 +103,7 @@ class Simulator:
         )
         self.beam.alm = map2alm(hp_maps, self.lmax)
 
-    def compute_dpss(self, nterms=None):
-        if nterms is None:
-            nterms = self.nterms
+    def compute_dpss(self):
         # generate the set of target frequencies (subset of all freqs)
         x = np.unique(
             np.concatenate(

--- a/croissant/simulator.py
+++ b/croissant/simulator.py
@@ -116,7 +116,7 @@ class Simulator:
             )
         )
 
-        self.design_matrix = dpss.dpss_op(x, nterms=nterms)
+        self.design_matrix = dpss.dpss_op(x, nterms=self.nterms)
         self.sky.coeffs = dpss.freq2dpss(
             self.sky.alm,
             self.sky.frequencies,

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -92,7 +92,8 @@ def test_compute_dpss():
     sim = Simulator(
         beam, sky, loc, t_start, N_times=N_times, delta_t=delta_t, lmax=lmax
     )
-    sim.compute_dpss(nterms=10)
+    sim.nterms = 10
+    sim.compute_dpss()
     design_matrix = dpss.dpss_op(frequencies, nterms=10)
     assert np.allclose(design_matrix, sim.design_matrix)
     sky_alm = rotate_alm(sky.alm(lmax=lmax))


### PR DESCRIPTION
simulator used to be able to modify the instance of the beam it depended on. This gave unexpected behaviour, for example, running a simulation twice at different locations would give the same results since the beam coordinate system would be changed to equatorial