### PR TITLE
specify hera filter version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,8 +20,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[dev]
-          python -m pip install git+https://github.com/HERA-Team/hera_filters.git
-          python -m pip install git+https://github.com/telegraphic/pygdsm.git
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages=find:
 install_requires =
     astropy
     healpy
-    hera-filters
+    hera-filters == 0.1.1
     jupyter
     lunarsky
     matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     jupyter
     lunarsky
     matplotlib
-    numpy
+    numpy <= 1.23
     pygdsm
     scipy
 


### PR DESCRIPTION
Hera Filters require python3.8 as of v.0.1.3. Since the parts of hera filters that croissant relies on hasn't been substantially upgraded since v0.1.1 (which supports python3.7), we specify hera-filters==0.1.1 to keep supporting python3.7 for now.