### PR TITLE
Fix beam index

### DIFF
--- a/croissant/beam.py
+++ b/croissant/beam.py
@@ -38,7 +38,7 @@ class Beam(Alm):
             horizon = np.ones_like(hp_beam)
             npix = horizon.shape[-1]
             theta = pix2ang(nside, np.arange(npix))[0]
-            horizon[:, theta > np.pi / 2] = 0
+            horizon[..., theta > np.pi / 2] = 0
 
         hp_beam *= horizon
         self.alm = map2alm(hp_beam, lmax=self.lmax)

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -28,11 +28,27 @@ def test_compute_total_power():
 
 
 def test_horizon_cut():
-    # make a beam that is 1 everywhere so total power is 4pi:
+    # make a beam that is 1 everywhere
     data = np.ones((theta.size, phi.size))
-    beam = Beam.from_grid(data, theta, phi, lmax)
+    beam_base = Beam.from_grid(data, theta, phi, lmax)
+
+    # default horizon (1 frequency)
+    beam = deepcopy(beam_base)
+    beam.horizon_cut()  # doesn't throw error
+
+    # default horizon (multiple frequencies)
+    data_nf = np.ones((frequencies.size, theta.size, phi.size))
+    beam_nf = Beam.from_grid(
+        data_nf, theta, phi, lmax, frequencies=frequencies
+    )
+    beam_nf.horizon_cut()  # doesn't throw error
+    assert np.allclose(
+        beam_nf.alm,
+        np.repeat(np.expand_dims(beam.alm, axis=0), frequencies.size, axis=0)
+    )
 
     # try custom horizon
+    beam = deepcopy(beam_base)
     nside = 64
     npix = hp.nside2npix(nside)
     horizon = np.ones(npix)  # no horizon
@@ -41,6 +57,7 @@ def test_horizon_cut():
     # should be the same before and after since the horizon is all 1s
     assert np.allclose(beam_map, beam.hp_map(nside=nside))
 
+    beam = deepcopy(beam_base)
     horizon = np.zeros(npix)  # full horizon
     beam.horizon_cut(horizon=horizon, nside=nside)
     # should be all zeros since the horizon is all 0s

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import healpy as hp
 import numpy as np
 import pytest
@@ -44,7 +45,7 @@ def test_horizon_cut():
     beam_nf.horizon_cut()  # doesn't throw error
     assert np.allclose(
         beam_nf.alm,
-        np.repeat(np.expand_dims(beam.alm, axis=0), frequencies.size, axis=0)
+        np.repeat(np.expand_dims(beam.alm, axis=0), frequencies.size, axis=0),
     )
 
     # try custom horizon


### PR DESCRIPTION
The default horizon cut did not take into account when the ndim of the beam object was 1 (i.e., no frequencies specified). Here we fix this and add a test that would've failed previously and passes now.