### PR TITLE
add frequency kwarg to alm2map 

### DIFF
--- a/croissant/healpix.py
+++ b/croissant/healpix.py
@@ -531,7 +531,7 @@ class Alm(hp.Alm):
             indices = np.isin(
                 self.frequencies, frequencies, assume_unique=True
             ).nonzero()[0]
-            if indices.size < frequencies.size:
+            if indices.size < np.size(frequencies):
                 warnings.warn(
                     "Some of the frequencies specified are not in"
                     "alm.frequencies.",

--- a/croissant/healpix.py
+++ b/croissant/healpix.py
@@ -527,7 +527,15 @@ class Alm(hp.Alm):
         if frequencies is None:
             alm = self.alm
         else:
-            indices = np.isin(self.frequencies, frequencies).nonzero()[0]
+            indices = np.isin(
+                self.frequencies, frequencies, assume_unique=True
+            ).nonzero()[0]
+            if indices.size < frequencies.size:
+                warnings.warn(
+                    "Some of the frequencies specified are not in"
+                    "alm.frequencies.",
+                    UserWarning,
+                )
             alm = self.alm[indices]
         m = alm2map(alm, nside=nside, lmax=self.lmax)
         return m

--- a/croissant/healpix.py
+++ b/croissant/healpix.py
@@ -506,11 +506,31 @@ class Alm(hp.Alm):
         else:
             return self.lmax
 
-    def hp_map(self, nside):
+    def hp_map(self, nside, frequencies=None):
         """
-        Construct a healpy map from the Alm.
+        Construct a healpy map from the Alm for the given frequencies.
+
+        Parameters
+        ----------
+        nside : int
+            The nside of the Healpix map to construct.
+        frequencies : array_like
+            The frequencies to construct the map for. If None, the map will
+            be constructed for all frequencies.
+
+        Returns
+        -------
+        m : np.ndarray
+            The Healpix map(s) (shape = (Nfreq, 12 * nside ** 2)).
+
         """
-        return alm2map(self.alm, nside=nside, lmax=self.lmax)
+        if frequencies is None:
+            alm = self.alm
+        else:
+            indices = np.isin(self.frequencies, frequencies).nonzero()[0]
+            alm = self.alm[indices]
+        m = alm2map(alm, nside=nside, lmax=self.lmax)
+        return m
 
     def rot_alm_z(self, phi=None, times=None, world="moon"):
         """

--- a/croissant/healpix.py
+++ b/croissant/healpix.py
@@ -1,6 +1,7 @@
 import healpy as hp
 import numpy as np
 from scipy.interpolate import RectSphereBivariateSpline
+import warnings
 
 from . import constants
 from .rotations import Rotator

--- a/tests/test_healpix.py
+++ b/tests/test_healpix.py
@@ -404,7 +404,7 @@ def test_hp_map():
     assert np.allclose(hp_map_select, hp_map[freq_indices])
 
     # use some frequencies that are not in alm.frequencies
-    with pytest.raises(UserWarning):
+    with pytest.warns(UserWarning):
         alm.hp_map(nside=nside, frequencies=[0, 30, 100])
 
 

--- a/tests/test_healpix.py
+++ b/tests/test_healpix.py
@@ -391,6 +391,18 @@ def test_hp_map():
     expected_maps *= frequencies.reshape(-1, 1)
     assert np.allclose(hp_map, expected_maps)
 
+    # use subset of frequencies and compare to full set
+    alm = hp.Alm(alm_arr, lmax=lmax, frequencies=frequencies)
+    # some random map
+    alm[:, 0, 0] = a00 * frequencies
+    alm[:, 1, 1] = 2 * a00 * frequencies
+    alm[::2, 8, 3] = -3 * a00 * frequencies[::2]
+    hp_map = alm.hp_map(nside=nside)
+    freq_indices = [10, 20, 35]  # indices of frequencies to use
+    freqs = frequencies[freq_indices]  # frequencies to use
+    hp_map_select = alm.hp_map(nside=nside, frequencies=freqs)
+    assert np.allclose(hp_map_select, hp_map[freq_indices])
+
 
 def test_rot_alm_z():
     lmax = 10

--- a/tests/test_healpix.py
+++ b/tests/test_healpix.py
@@ -403,6 +403,10 @@ def test_hp_map():
     hp_map_select = alm.hp_map(nside=nside, frequencies=freqs)
     assert np.allclose(hp_map_select, hp_map[freq_indices])
 
+    # use some frequencies that are not in alm.frequencies
+    with pytest.raises(UserWarning):
+        alm.hp_map(nside=nside, frequencies=[0, 30, 100])
+
 
 def test_rot_alm_z():
     lmax = 10


### PR DESCRIPTION
The function cro.Alm().hp_map which calls healpix.alm2map currently computes the healpix map for every frequency in the alm. Usually for plotting, we only care about a select number of frequencies. This kwarg adds that option.