### PR TITLE
Add codecov token and revert to v3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,3 +33,6 @@ jobs:
           pytest --cov=croissant --cov-report=xml tests/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           pytest --cov=croissant --cov-report=xml tests/
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Dependabot bumped codecov to v4, but we revert this since v4 is still in beta. However, we preemptively add a token, since token-less upload will be removed in v4.