### PR TITLE
fix compatbility issue with python3.12

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,18 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          #cache: 'pip'
-      - name: Clean Python build cache
-        run: rm -rf build dist *.egg-info ~/.cache/pip
-
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          #cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,11 +17,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           #cache: 'pip'
+      - name: Clean Python build cache
+        run: rm -rf build dist *.egg-info ~/.cache/pip
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade "jax[cpu]"
-          python -m pip install .[dev]
+          python -m pip install --no-cache-dir .[dev]
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade "jax[cpu]"
           python -m pip install .[dev]
       - name: Lint with flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "setuptools_scm >= 6", "wheel"]
+requires = ["setuptools >= 65", "setuptools_scm >= 8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ python_requires = >= 3.8
 packages=find:
 install_requires =
     astropy
+    distutils
     hera-filters == 0.1.1
     jupyter
     lunarsky

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ python_requires = >= 3.8
 packages=find:
 install_requires =
     astropy
-    distutils
+    setuptools
     hera-filters == 0.1.1
     jupyter
     lunarsky

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.10
 packages=find:
 install_requires =
     astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,13 +19,12 @@ python_requires = >= 3.8
 packages=find:
 install_requires =
     astropy
-    setuptools
-    hera-filters == 0.1.1
+    hera-filters
     jupyter
     lunarsky
     matplotlib
-    numpy <= 1.23
-    pygdsm == 1.5.0
+    numpy
+    pygdsm
     s2fft @ git+https://github.com/astro-informatics/s2fft.git
 
 [options.extras_require]


### PR DESCRIPTION
there was a dependency issue where croissant couldn't be installed with python3.12. This is now fixed. Support for Python < 3.10 is also dropped.