### PR TITLE
fix: handle gimbal lock in rotmat_to_eulerZYZ

### DIFF
--- a/src/croissant/rotations.py
+++ b/src/croissant/rotations.py
@@ -180,10 +180,22 @@ def rotmat_to_eulerZYZ(mat):
         s2fft.utils.rotation.rotate_flms expects.
 
     """
-    alpha = np.arctan2(mat[1, 2], mat[0, 2])
-    cos_beta = mat[2, 2]
-    beta = np.arctan2(np.sqrt(1 - cos_beta**2), cos_beta)
-    gamma = np.arctan2(mat[2, 1], -mat[2, 0])
+    cos_beta = np.clip(mat[2, 2], -1.0, 1.0)
+    sin_beta = np.sqrt(1 - cos_beta**2)
+    beta = np.arctan2(sin_beta, cos_beta)
+    if np.isclose(beta, 0.0):
+        # Gimbal lock at beta=0: R = Rz(alpha + gamma).
+        # Set gamma = 0 and absorb the full rotation into alpha.
+        gamma = 0.0
+        alpha = np.arctan2(-mat[0, 1], mat[0, 0])
+    elif np.isclose(beta, np.pi):
+        # Gimbal lock at beta=pi: R depends only on alpha - gamma.
+        # Set gamma = 0 and absorb into alpha.
+        gamma = 0.0
+        alpha = np.arctan2(-mat[0, 1], mat[1, 1])
+    else:
+        alpha = np.arctan2(mat[1, 2], mat[0, 2])
+        gamma = np.arctan2(mat[2, 1], -mat[2, 0])
     eul = (alpha, beta, gamma)
     return eul
 

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -117,7 +117,7 @@ def test_rotmat_to_eulerZYZ_roundtrip():
 
 
 def test_rotmat_to_eulerZYZ_gimbal_lock():
-    """ZYZ decomposition must handle beta=0 (pure z-rotation)."""
+    """ZYZ decomposition must handle beta=0 and beta=pi (pure z-rotation)."""
     # pure z-rotations: beta = 0, only alpha + gamma matters
     for angle in [0, np.pi / 4, np.pi / 2, np.pi, -1.2, 2.7]:
         rot_mat = _rz(angle)

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -80,6 +80,65 @@ def test_rotmat_to_euler():
     assert np.allclose(rot_mat, rmat)
 
 
+def _rz(angle):
+    c, s = np.cos(angle), np.sin(angle)
+    return np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]])
+
+
+def _ry(angle):
+    c, s = np.cos(angle), np.sin(angle)
+    return np.array([[c, 0, s], [0, 1, 0], [-s, 0, c]])
+
+
+def _euler_to_rotmat(alpha, beta, gamma):
+    """Reconstruct rotation matrix from ZYZ Euler angles."""
+    return _rz(alpha) @ _ry(beta) @ _rz(gamma)
+
+
+def test_rotmat_to_eulerZYZ_roundtrip():
+    """rotmat_to_eulerZYZ should round-trip for arbitrary matrices."""
+    # generic rotation (beta != 0)
+    rot_mat = rotations.get_rot_mat("galactic", "fk5")
+    eul = rotations.rotmat_to_eulerZYZ(rot_mat)
+    rmat = _euler_to_rotmat(*eul)
+    assert np.allclose(rot_mat, rmat)
+
+    # another generic rotation
+    rot_mat = rotations.get_rot_mat("galactic", "mepa")
+    eul = rotations.rotmat_to_eulerZYZ(rot_mat)
+    rmat = _euler_to_rotmat(*eul)
+    assert np.allclose(rot_mat, rmat)
+
+    # permutation matrix
+    rot_mat = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]], dtype=float)
+    eul = rotations.rotmat_to_eulerZYZ(rot_mat)
+    rmat = _euler_to_rotmat(*eul)
+    assert np.allclose(rot_mat, rmat)
+
+
+def test_rotmat_to_eulerZYZ_gimbal_lock():
+    """ZYZ decomposition must handle beta=0 (pure z-rotation)."""
+    # pure z-rotations: beta = 0, only alpha + gamma matters
+    for angle in [0, np.pi / 4, np.pi / 2, np.pi, -1.2, 2.7]:
+        rot_mat = _rz(angle)
+        eul = rotations.rotmat_to_eulerZYZ(rot_mat)
+        rmat = _euler_to_rotmat(*eul)
+        assert np.allclose(rot_mat, rmat, atol=1e-14), (
+            f"round-trip failed for Rz({angle}): euler={eul}"
+        )
+
+    # beta = pi (mat[2,2] = -1): Rz(a) @ Ry(pi) @ Rz(g)
+    rot_mat = _rz(0.3) @ _ry(np.pi) @ _rz(0.7)
+    eul = rotations.rotmat_to_eulerZYZ(rot_mat)
+    rmat = _euler_to_rotmat(*eul)
+    assert np.allclose(rot_mat, rmat, atol=1e-14)
+
+    # identity
+    eul = rotations.rotmat_to_eulerZYZ(np.eye(3))
+    rmat = _euler_to_rotmat(*eul)
+    assert np.allclose(rmat, np.eye(3), atol=1e-14)
+
+
 def test_mepa_rotation_matrix():
     """MEPA rotation matrix should be a proper rotation (det=+1)."""
     R = rotations.get_mepa_rotation_matrix()


### PR DESCRIPTION
## Summary

- Fix gimbal lock in `rotmat_to_eulerZYZ` for the degenerate cases `beta=0` and `beta=pi`
- Previously, any pure `Rz(angle)` matrix returned Euler angles `(0, 0, pi)` regardless of the actual angle, because `arctan2(0, -0.0) = pi` per IEEE 754
- This caused downstream Wigner-D rotations (e.g. in eigsim) to silently apply `Rz(pi)` instead of the intended rotation
- The fix mirrors the gimbal lock handling already present in `rotmat_to_eulerZYX`

## Test plan

- [x] Added `test_rotmat_to_eulerZYZ_roundtrip` — round-trip test for generic rotations
- [x] Added `test_rotmat_to_eulerZYZ_gimbal_lock` — tests beta=0 (pure z-rotations at several angles), beta=pi, and identity
- [x] Full test suite passes (442 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)