### PR TITLE
test: speedup tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ pythonpath = ["src"]
 addopts = [
   "--cov=src",
   "--cov-report=term-missing",
-  "--cov-report=html",
   "--junitxml=junit.xml",
   "-o junit_family=legacy",
   "--timeout=120",

--- a/tests/test_sim_class.py
+++ b/tests/test_sim_class.py
@@ -23,7 +23,7 @@ rng = np.random.default_rng(seed=3)
 _NSIDE = 8
 _LMAX = 2 * _NSIDE
 _NPIX = 12 * _NSIDE**2
-_FREQS = jnp.linspace(50.0, 100.0, num=50)
+_FREQS = jnp.linspace(50.0, 100.0, num=5)
 _N_FREQS = len(_FREQS)
 
 _TSKY = 180 * (_FREQS / 180) ** (-2.5)  # power-law sky temperature in K
@@ -258,7 +258,7 @@ def test_compute_beam_eq_shape():
     assert beam_eq.shape == (_N_FREQS, _LMAX + 1, 2 * _LMAX + 1)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def vis_highres():
     """
     High-resolution visibility for testing ground loss correction.

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -10,7 +10,7 @@ from croissant import utils
 from croissant.constants import Y00
 from croissant.sphere import SphBase, compute_alm
 
-pytestmark = pytest.mark.parametrize("lmax", [8, 16, 25])
+LMAX_PARAMS = [8, 16, 25]
 rng = np.random.default_rng(seed=0)
 
 SAMPLING_PARAMS = [
@@ -43,6 +43,7 @@ def _make_data(lmax, sampling, N_freqs=50):
     return np.ones((N_freqs, ntheta, nphi))
 
 
+@pytest.mark.parametrize("lmax", LMAX_PARAMS)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS)
 def test_sphbase_init(sampling, lmax):
     """SphBase should initialize with correct attributes."""
@@ -68,6 +69,7 @@ def test_sphbase_init(sampling, lmax):
     assert obj.data.shape == data.shape
 
 
+@pytest.mark.parametrize("lmax", LMAX_PARAMS)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS)
 def test_sphbase_theta_phi_shape(sampling, lmax):
     """Theta and phi arrays should have consistent shapes."""
@@ -86,6 +88,7 @@ def test_sphbase_theta_phi_shape(sampling, lmax):
         assert obj.phi.shape == (nphi,)
 
 
+@pytest.mark.parametrize("lmax", LMAX_PARAMS)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS)
 def test_sphbase_theta_range(sampling, lmax):
     """Theta values should be in [0, pi]."""
@@ -95,6 +98,7 @@ def test_sphbase_theta_range(sampling, lmax):
     assert jnp.all(obj.theta < jnp.pi + 1e-10)
 
 
+@pytest.mark.parametrize("lmax", LMAX_PARAMS)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS)
 def test_sphbase_phi_range(sampling, lmax):
     """Phi values should be in [0, 2*pi)."""
@@ -104,12 +108,13 @@ def test_sphbase_phi_range(sampling, lmax):
     assert jnp.all(obj.phi < 2 * jnp.pi + 1e-10)
 
 
-@pytest.mark.parametrize("disable_jit", [True, False])
+@pytest.mark.parametrize(
+    "disable_jit, lmax",
+    [(True, 8), (False, 8), (False, 16), (False, 25)],
+)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS_JIT_SAFE)
 def test_compute_alm_shape(sampling, lmax, disable_jit):
     """compute_alm should return array of shape (N_freqs, lmax+1, 2*lmax+1)."""
-    if disable_jit and lmax > 8:
-        pytest.skip("disable_jit only tested with smallest lmax")
     N_freqs = 3
     data = jnp.array(_make_data(lmax, sampling, N_freqs))
     if sampling == "healpix":
@@ -122,6 +127,7 @@ def test_compute_alm_shape(sampling, lmax, disable_jit):
     assert alm.shape == (N_freqs, lmax + 1, 2 * lmax + 1)
 
 
+@pytest.mark.parametrize("lmax", LMAX_PARAMS)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS_JIT_SAFE)
 def test_compute_alm_niter(sampling, lmax):
     """compute_alm with a non-default niter should return correct shape."""
@@ -136,6 +142,7 @@ def test_compute_alm_niter(sampling, lmax):
     assert alm.shape == (N_freqs, lmax + 1, 2 * lmax + 1)
 
 
+@pytest.mark.parametrize("lmax", LMAX_PARAMS)
 def test_compute_alm_healpix_niter_reduces_error(lmax):
     """
     niter=3 for healpix should reduce forward/inverse reconstruction
@@ -172,12 +179,13 @@ def test_compute_alm_healpix_niter_reduces_error(lmax):
     assert err3 < err0
 
 
-@pytest.mark.parametrize("disable_jit", [True, False])
+@pytest.mark.parametrize(
+    "disable_jit, lmax",
+    [(True, 8), (False, 8), (False, 16), (False, 25)],
+)
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS_JIT_SAFE)
 def test_compute_alm_monopole(sampling, lmax, disable_jit):
     """Uniform map should produce a dominant monopole component."""
-    if disable_jit and lmax > 8:
-        pytest.skip("disable_jit only tested with smallest lmax")
 
     T = 500.0
     N_freqs = 1

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -108,6 +108,8 @@ def test_sphbase_phi_range(sampling, lmax):
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS_JIT_SAFE)
 def test_compute_alm_shape(sampling, lmax, disable_jit):
     """compute_alm should return array of shape (N_freqs, lmax+1, 2*lmax+1)."""
+    if disable_jit and lmax > 8:
+        pytest.skip("disable_jit only tested with smallest lmax")
     N_freqs = 3
     data = jnp.array(_make_data(lmax, sampling, N_freqs))
     if sampling == "healpix":
@@ -174,6 +176,8 @@ def test_compute_alm_healpix_niter_reduces_error(lmax):
 @pytest.mark.parametrize("sampling", SAMPLING_PARAMS_JIT_SAFE)
 def test_compute_alm_monopole(sampling, lmax, disable_jit):
     """Uniform map should produce a dominant monopole component."""
+    if disable_jit and lmax > 8:
+        pytest.skip("disable_jit only tested with smallest lmax")
 
     T = 500.0
     N_freqs = 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -236,17 +236,19 @@ class TestAlmUtils:
         assert jnp.allclose(ms, ms_)
 
     def test_getlm(self, lmax):
-        alm = jnp.zeros(cro.utils.shape_from_lmax(lmax), dtype=jnp.complex128)
-        nrows, ncols = alm.shape
-        # l correspond to rows, m correspond to columns
-        ls = jnp.arange(nrows)
-        ms = jnp.arange(ncols) - lmax
-        for i in range(nrows):
-            for j in range(ncols):
-                ix = (i, j)
-                ell, emm = cro.utils.getlm(lmax, ix)
-                assert ell == ls[i]
-                assert emm == ms[j]
+        nrows, ncols = cro.utils.shape_from_lmax(lmax)
+        rows, cols = jnp.meshgrid(
+            jnp.arange(nrows), jnp.arange(ncols), indexing="ij"
+        )
+        ells, emms = cro.utils.getlm(lmax, (rows, cols))
+        expected_ls = jnp.broadcast_to(
+            jnp.arange(nrows)[:, None], (nrows, ncols)
+        )
+        expected_ms = jnp.broadcast_to(
+            jnp.arange(ncols)[None, :] - lmax, (nrows, ncols)
+        )
+        assert jnp.array_equal(ells, expected_ls)
+        assert jnp.array_equal(emms, expected_ms)
 
     def test_lmax_from_shape(self, lmax):
         shape = s2fft.sampling.s2_samples.flm_shape(lmax + 1)


### PR DESCRIPTION
The test suite is slow ~8 mins for 440 tests. This speeds up to about ~5 minutes without decrreasing test coverage by sharing simulation results between tests, running disable_jit only for low lmax, and reduce unnecessary calls to slow functions in some cases.