### PR TITLE
feat: add dense spherical harmonic engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Add an optional `engine="dense"` spherical harmonic transform backend for
+  repeated low-band-limit workloads. It builds the exact configured `s2fft`
+  analysis operator once in bounded chunks, caches only independent
+  coefficients on the JAX device, and preserves JIT compilation, batching,
+  iterative refinement, and automatic differentiation.
+- Allow HEALPix `Beam` and `Sky` objects to set an explicit lower `lmax`
+  independently of their pixel resolution.
+
 ## [5.2.1](https://github.com/christianhbye/croissant/compare/croissant-sim-v5.2.0...croissant-sim-v5.2.1) (2026-04-06)
 
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,38 @@ Moreover, the time evolution of the simulation is very natural in this represent
 
 Overall, this makes CROISSANT a very fast visibility simulator. CROISSANT can therefore be used to simulate a large combination of antenna models and sky models - allowing for the exploration of a range of propsed designs before choosing an antenna for an experiment.
 
+### Dense low-band-limit transforms
+
+For repeated transforms at low spherical-harmonic band-limits, `Beam` and
+`Sky` accept `engine="dense"`:
+
+```python
+sky = croissant.Sky(
+    maps,
+    frequencies,
+    sampling="healpix",
+    engine="dense",
+    lmax=30,
+)
+alm = sky.compute_alm()
+```
+
+On first construction, Croissant evaluates the spherical-harmonic basis in
+bounded chunks and caches the resulting analysis matrix on the current JAX
+device. Later transforms are native JAX matrix multiplications, so they
+support JIT compilation, batching, and automatic differentiation without
+external callbacks. The cached matrix includes the selected `niter`
+refinement count and stores only the independent `m >= 0` coefficients.
+HEALPix inputs may set `lmax` below the usual `2 * nside` default, which is
+particularly useful for high-resolution maps with low-band-limit science.
+
+`engine="s2fft"` remains the default. Applications that call
+`croissant.sphere.compute_alm` from inside an enclosing `jax.jit` can warm the
+cache explicitly with `croissant.precompute_dense_matrix`; `Beam` and `Sky`
+do this automatically during initialization. Use
+`croissant.clear_dense_matrix_cache()` to release Croissant's in-process
+matrix references.
+
 ## Installation
 To install the package for standard use, you can use your preferred Python package manager:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "lunarsky",
   "numpy",
   "s2fft",
+  "scipy",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable", 

--- a/src/croissant/__init__.py
+++ b/src/croissant/__init__.py
@@ -4,6 +4,7 @@ from . import constants, multipair, rotations, simulator, utils
 from .beam import Beam
 from .simulator import Simulator
 from .sky import Sky
+from .sphere import clear_dense_matrix_cache, precompute_dense_matrix
 
 # isort: split
 from . import alm

--- a/src/croissant/beam.py
+++ b/src/croissant/beam.py
@@ -19,6 +19,8 @@ class Beam(sphere.SphBase):
         beam_rot=0.0,
         beam_tilt=0.0,
         niter=0,
+        engine="s2fft",
+        lmax=None,
     ):
         """
         Beam pattern object. Holds the beam pattern in local antenna
@@ -64,9 +66,23 @@ class Beam(sphere.SphBase):
             when using iterative methods. Default is 0 for all sampling
             schemes. For healpix, setting niter=3 improves accuracy
             but significantly increases JIT compile time.
+        engine : {"s2fft", "dense"}
+            Spherical harmonic transform engine. Default is ``"s2fft"``.
+            The ``"dense"`` engine caches an exact transform matrix and is
+            optimized for repeated low-band-limit transforms.
+        lmax : int or None
+            Maximum spherical harmonic degree. For HEALPix data this may be
+            lower than the default ``2 * nside``. Default is None.
 
         """
-        super().__init__(data, freqs, sampling, niter=niter)
+        super().__init__(
+            data,
+            freqs,
+            sampling,
+            niter=niter,
+            engine=engine,
+            lmax=lmax,
+        )
 
         if not jnp.isclose(beam_tilt, 0.0):
             raise NotImplementedError("Beam tilt is not yet implemented.")
@@ -171,6 +187,8 @@ class Beam(sphere.SphBase):
             self.sampling,
             nside=self.nside,
             niter=self._niter,
+            engine=self._engine,
+            dense_matrix=self._dense_matrix,
         )
         # apply azimuthal rotation, N→E convention (no-op when beam_rot == 0)
         emms = jnp.arange(-self.lmax, self.lmax + 1)

--- a/src/croissant/sky.py
+++ b/src/croissant/sky.py
@@ -8,7 +8,14 @@ class Sky(sphere.SphBase):
     coord: str = eqx.field(static=True)
 
     def __init__(
-        self, data, freqs, sampling="healpix", coord="galactic", niter=0
+        self,
+        data,
+        freqs,
+        sampling="healpix",
+        coord="galactic",
+        niter=0,
+        engine="s2fft",
+        lmax=None,
     ):
         """
         Object that holds the sky model.
@@ -37,6 +44,13 @@ class Sky(sphere.SphBase):
             transform. Default is 0 for all sampling schemes. For
             healpix, setting niter=3 improves accuracy but
             significantly increases JIT compile time.
+        engine : {"s2fft", "dense"}
+            Spherical harmonic transform engine. Default is ``"s2fft"``.
+            The ``"dense"`` engine caches an exact transform matrix and is
+            optimized for repeated low-band-limit transforms.
+        lmax : int or None
+            Maximum spherical harmonic degree. For HEALPix data this may be
+            lower than the default ``2 * nside``. Default is None.
 
         """
         if coord not in {"galactic", "equatorial", "mepa"}:
@@ -44,7 +58,14 @@ class Sky(sphere.SphBase):
                 f"Unsupported coordinate system: {coord}. Supported systems "
                 "are {'galactic', 'equatorial', 'mepa'}."
             )
-        super().__init__(data, freqs, sampling, niter=niter)
+        super().__init__(
+            data,
+            freqs,
+            sampling,
+            niter=niter,
+            engine=engine,
+            lmax=lmax,
+        )
         self.coord = coord
 
     @jax.jit
@@ -60,6 +81,8 @@ class Sky(sphere.SphBase):
             self.sampling,
             nside=self.nside,
             niter=self._niter,
+            engine=self._engine,
+            dense_matrix=self._dense_matrix,
         )
 
     def compute_alm_eq(self, world="moon", et=None):

--- a/src/croissant/sphere.py
+++ b/src/croissant/sphere.py
@@ -1,20 +1,339 @@
 from functools import partial
+from threading import RLock
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 import s2fft
 
 from . import utils
 
+_DENSE_MATRIX_CACHE = {}
+_DENSE_MATRIX_CACHE_LOCK = RLock()
+
+
+def _dense_matrix_key(spatial_shape, lmax, sampling, nside, niter, dtype):
+    """Return a hashable key for a cached dense SHT analysis matrix."""
+    return (
+        tuple(spatial_shape),
+        int(lmax),
+        str(sampling),
+        None if nside is None else int(nside),
+        int(niter),
+        np.dtype(dtype).str,
+        jax.default_backend(),
+    )
+
+
+def _positive_lm_indices(lmax):
+    """Indices for healpy-ordered, independent m >= 0 coefficients."""
+    ell = np.concatenate(
+        [np.arange(m, lmax + 1, dtype=np.int32) for m in range(lmax + 1)]
+    )
+    emm = np.concatenate(
+        [np.full(lmax - m + 1, m, dtype=np.int32) for m in range(lmax + 1)]
+    )
+    return ell, emm
+
 
 @eqx.filter_jit
-def compute_alm(data, lmax, sampling, nside=None, niter=0):
+def _compute_alm_s2fft(data, lmax, sampling, nside=None, niter=0):
+    """Compute alms with the standard matrix-free s2fft engine."""
+    m2alm = partial(
+        s2fft.forward,
+        L=lmax + 1,
+        spin=0,
+        nside=nside,
+        sampling=sampling,
+        method="jax",
+        reality=True,
+        precomps=None,
+        spmd=False,
+        L_lower=0,
+        iter=niter,
+    )
+    return jax.vmap(m2alm)(data)
+
+
+def _build_dense_matrix_healpix(
+    spatial_shape,
+    lmax,
+    nside,
+    niter,
+    dtype,
+    chunk_size,
+):
+    """Build a HEALPix matrix by evaluating spherical harmonics directly."""
+    from scipy import special
+
+    npix = int(np.prod(spatial_shape))
+    if spatial_shape != (npix,):
+        raise ValueError("HEALPix maps must have one spatial pixel axis")
+
+    ell, emm = _positive_lm_indices(lmax)
+    nalm = len(ell)
+    complex_dtype = jnp.complex128 if jax.config.x64_enabled else jnp.complex64
+    if chunk_size is None:
+        # Limit each host-side spherical-harmonic block to roughly 64 MiB.
+        complex_itemsize = np.dtype(complex_dtype).itemsize
+        chunk_size = min(256, max(1, (64 << 20) // (npix * complex_itemsize)))
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be a positive integer")
+    chunk_size = min(int(chunk_size), nalm)
+
+    theta = np.asarray(
+        utils.generate_theta(lmax=None, sampling="healpix", nside=nside)
+    )
+    phi = np.asarray(
+        utils.generate_phi(lmax=None, sampling="healpix", nside=nside)
+    )
+    blocks = []
+    for start in range(0, nalm, chunk_size):
+        stop = min(start + chunk_size, nalm)
+        ell_chunk = ell[start:stop, None]
+        emm_chunk = emm[start:stop, None]
+        if hasattr(special, "sph_harm_y"):
+            block = special.sph_harm_y(
+                ell_chunk,
+                emm_chunk,
+                theta[None, :],
+                phi[None, :],
+            )
+        else:  # pragma: no cover - SciPy < 1.15 compatibility
+            block = special.sph_harm(
+                emm_chunk,
+                ell_chunk,
+                phi[None, :],
+                theta[None, :],
+            )
+        blocks.append(block.astype(np.dtype(complex_dtype)))
+    harmonics = jnp.asarray(np.concatenate(blocks, axis=0))
+
+    pixel_area = jnp.asarray(4 * np.pi / npix, dtype=harmonics.real.dtype)
+    if niter == 0:
+        return pixel_area * jnp.conj(harmonics)
+
+    # For iterative refinement, express synthesis and analysis in the L**2
+    # independent real harmonic degrees of freedom: m=0 contributes one real
+    # value, while m>0 contributes real and imaginary parts.
+    packed_real = []
+    packed_imag = []
+    row = 0
+    for m in range(lmax + 1):
+        for _ in range(m, lmax + 1):
+            packed_real.append(row)
+            row += 1
+            if m == 0:
+                packed_imag.append(-1)
+            else:
+                packed_imag.append(row)
+                row += 1
+
+    packed_real = np.asarray(packed_real, dtype=np.int32)
+    packed_imag = np.asarray(packed_imag, dtype=np.int32)
+    ndof = (lmax + 1) ** 2
+    synthesis = jnp.zeros((ndof, npix), dtype=harmonics.real.dtype)
+    base = jnp.zeros_like(synthesis)
+
+    zero = emm == 0
+    synthesis = synthesis.at[packed_real].set(
+        jnp.where(zero[:, None], harmonics.real, 2 * harmonics.real)
+    )
+    base = base.at[packed_real].set(pixel_area * harmonics.real)
+
+    positive = ~zero
+    synthesis = synthesis.at[packed_imag[positive]].set(
+        -2 * harmonics.imag[positive]
+    )
+    base = base.at[packed_imag[positive]].set(
+        -pixel_area * harmonics.imag[positive]
+    )
+
+    analysis = base
+    gram = base @ synthesis.T
+    for _ in range(niter):
+        analysis = analysis + base - gram @ analysis
+
+    matrix = analysis[packed_real].astype(complex_dtype)
+    positive = packed_imag >= 0
+    matrix = matrix.at[positive].add(1j * analysis[packed_imag[positive]])
+    return matrix
+
+
+def _build_dense_matrix_from_pixels(
+    spatial_shape,
+    lmax,
+    sampling,
+    nside,
+    niter,
+    dtype,
+    chunk_size=None,
+):
+    """Materialize a general s2fft analysis operator from pixel bases."""
+    npix = int(np.prod(spatial_shape))
+    itemsize = np.dtype(dtype).itemsize
+    if chunk_size is None:
+        # Keep each identity-map chunk below 64 MiB. A ceiling of 256 gives
+        # enough batch parallelism on a GPU without making s2fft's vmapped
+        # intermediate arrays uncomfortably large.
+        chunk_size = min(256, max(1, (64 << 20) // (npix * itemsize)))
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be a positive integer")
+    chunk_size = min(int(chunk_size), npix)
+
+    ell, emm = _positive_lm_indices(lmax)
+    blocks = []
+    for start in range(0, npix, chunk_size):
+        stop = min(start + chunk_size, npix)
+        indices = jnp.arange(start, stop)
+        basis = jax.nn.one_hot(indices, npix, dtype=dtype)
+        basis = basis.reshape((stop - start,) + tuple(spatial_shape))
+        dense = _compute_alm_s2fft(
+            basis,
+            lmax,
+            sampling,
+            nside=nside,
+            niter=niter,
+        )
+        packed = dense[:, ell, lmax + emm].T
+        # Bound peak memory by ensuring that s2fft's much larger dense-layout
+        # result can be released before the next chunk is submitted.
+        blocks.append(packed.block_until_ready())
+
+    return jnp.concatenate(blocks, axis=1)
+
+
+def _build_dense_matrix(
+    spatial_shape,
+    lmax,
+    sampling,
+    nside,
+    niter,
+    dtype,
+    chunk_size=None,
+):
+    """Materialize the exact s2fft analysis operator in bounded chunks."""
+    if sampling.lower() == "healpix":
+        return _build_dense_matrix_healpix(
+            tuple(spatial_shape),
+            lmax,
+            nside,
+            niter,
+            dtype,
+            chunk_size,
+        )
+    return _build_dense_matrix_from_pixels(
+        spatial_shape,
+        lmax,
+        sampling,
+        nside,
+        niter,
+        dtype,
+        chunk_size=chunk_size,
+    )
+
+
+def precompute_dense_matrix(
+    spatial_shape,
+    lmax,
+    sampling,
+    nside=None,
+    niter=0,
+    dtype=jnp.float64,
+    chunk_size=None,
+):
     """
-    Compute the spherical harmonic coefficients of a scalar field on
-    the sphere. Wraps the s2fft.forward method in a convenient interface
-    and uses vmap to compute the coefficients for multiple frequencies
-    in parallel.
+    Build and cache a dense spherical harmonic analysis matrix.
+
+    The returned matrix stores only the independent ``m >= 0`` coefficients
+    and has shape ``((lmax + 1) * (lmax + 2) // 2, prod(spatial_shape))``.
+    It exactly represents Croissant's standard ``s2fft`` transform, including
+    the requested iterative-refinement count.
+
+    Parameters
+    ----------
+    spatial_shape : tuple of int
+        Shape of one input map, excluding its frequency axis.
+    lmax : int
+        Maximum spherical harmonic degree.
+    sampling : str
+        Spherical sampling scheme understood by s2fft.
+    nside : int or None
+        HEALPix nside, required for HEALPix sampling.
+    niter : int
+        Number of s2fft iterative-refinement steps to fold into the matrix.
+    dtype : dtype
+        Real input-map dtype.
+    chunk_size : int or None
+        Number of basis rows generated together while building the matrix.
+        The default bounds each input chunk to roughly 64 MiB, with a ceiling
+        of 256.
+
+    Returns
+    -------
+    matrix : jax.Array
+        Cached dense analysis matrix on the current default JAX device.
+    """
+    dtype = jax.dtypes.canonicalize_dtype(dtype)
+    key = _dense_matrix_key(spatial_shape, lmax, sampling, nside, niter, dtype)
+    with _DENSE_MATRIX_CACHE_LOCK:
+        matrix = _DENSE_MATRIX_CACHE.get(key)
+        if matrix is None:
+            matrix = _build_dense_matrix(
+                tuple(spatial_shape),
+                lmax,
+                sampling,
+                nside,
+                niter,
+                dtype,
+                chunk_size=chunk_size,
+            )
+            _DENSE_MATRIX_CACHE[key] = matrix
+    return matrix
+
+
+def clear_dense_matrix_cache():
+    """Remove all in-process dense SHT matrices from Croissant's cache."""
+    with _DENSE_MATRIX_CACHE_LOCK:
+        _DENSE_MATRIX_CACHE.clear()
+
+
+@partial(eqx.filter_jit, inline=True)
+def _apply_dense_matrix(data, matrix, lmax):
+    """Apply a packed dense analysis matrix and restore s2fft's layout."""
+    flat_data = data.reshape((data.shape[0], -1))
+    packed = flat_data @ matrix.T
+
+    ell, emm = _positive_lm_indices(lmax)
+    alm = jnp.zeros(
+        (data.shape[0], lmax + 1, 2 * lmax + 1),
+        dtype=packed.dtype,
+    )
+    alm = alm.at[:, ell, lmax + emm].set(packed)
+
+    positive = emm > 0
+    ell_neg = ell[positive]
+    emm_neg = emm[positive]
+    negative = ((-1) ** emm_neg)[None, :] * jnp.conj(packed[:, positive])
+    return alm.at[:, ell_neg, lmax - emm_neg].set(negative)
+
+
+def compute_alm(
+    data,
+    lmax,
+    sampling,
+    nside=None,
+    niter=0,
+    engine="s2fft",
+    *,
+    dense_matrix=None,
+):
+    """
+    Compute the spherical harmonic coefficients of a scalar field on the
+    sphere. The default ``"s2fft"`` engine wraps ``s2fft.forward``. The
+    ``"dense"`` engine materializes that same linear transform once and
+    subsequently evaluates it as a native JAX matrix multiplication.
 
     Parameters
     ----------
@@ -37,6 +356,14 @@ def compute_alm(data, lmax, sampling, nside=None, niter=0):
         improve accuracy at the cost of increased computation time.
         Default is 0, which corresponds to the default behavior of
         s2fft.
+    engine : {"s2fft", "dense"}
+        Spherical harmonic transform engine. ``"s2fft"`` is the existing
+        matrix-free implementation. ``"dense"`` caches the exact transform
+        matrix and is intended for low band-limits.
+    dense_matrix : jax.Array or None
+        Precomputed packed dense matrix. This is primarily used internally
+        by :class:`SphBase` so its jitted methods never build a matrix while
+        being traced.
 
     Returns
     -------
@@ -45,20 +372,44 @@ def compute_alm(data, lmax, sampling, nside=None, niter=0):
         (len(data), lmax+1, 2*lmax+1)
 
     """
-    m2alm = partial(
-        s2fft.forward,
-        L=lmax + 1,
-        spin=0,
-        nside=nside,
-        sampling=sampling,
-        method="jax",
-        reality=True,
-        precomps=None,
-        spmd=False,
-        L_lower=0,
-        iter=niter,
-    )
-    return jax.vmap(m2alm)(data)
+    if engine == "s2fft":
+        return _compute_alm_s2fft(
+            data,
+            lmax,
+            sampling,
+            nside=nside,
+            niter=niter,
+        )
+    if engine != "dense":
+        raise ValueError(
+            f"Unsupported SHT engine {engine!r}. Supported engines are "
+            "{'s2fft', 'dense'}."
+        )
+
+    if dense_matrix is None:
+        spatial_shape = tuple(data.shape[1:])
+        key = _dense_matrix_key(
+            spatial_shape, lmax, sampling, nside, niter, data.dtype
+        )
+        if isinstance(data, jax.core.Tracer):
+            with _DENSE_MATRIX_CACHE_LOCK:
+                dense_matrix = _DENSE_MATRIX_CACHE.get(key)
+            if dense_matrix is None:
+                raise RuntimeError(
+                    "The dense SHT matrix must be precomputed before "
+                    "compute_alm is called inside jax.jit. Call "
+                    "precompute_dense_matrix(...) once outside jax.jit."
+                )
+        else:
+            dense_matrix = precompute_dense_matrix(
+                spatial_shape,
+                lmax,
+                sampling,
+                nside=nside,
+                niter=niter,
+                dtype=data.dtype,
+            )
+    return _apply_dense_matrix(data, dense_matrix, lmax)
 
 
 class SphBase(eqx.Module):
@@ -68,11 +419,26 @@ class SphBase(eqx.Module):
     lmax: int = eqx.field(static=True)
     _L: int = eqx.field(static=True)  # L = lmax + 1 for s2fft
     _niter: int = eqx.field(static=True)  # niter for sht
+    _engine: str = eqx.field(static=True)  # spherical harmonic engine
+    _dense_matrix: jax.Array | None
     nside: int | None = eqx.field(static=True)
     theta: jax.Array  # in radians
     phi: jax.Array  # in radians
 
-    def __init__(self, data, freqs, sampling, niter=0):
+    @property
+    def engine(self):
+        """Name of the configured spherical harmonic transform engine."""
+        return self._engine
+
+    def __init__(
+        self,
+        data,
+        freqs,
+        sampling,
+        niter=0,
+        engine="s2fft",
+        lmax=None,
+    ):
         """
         Base class for scalar fields on the sphere. Holds the field
         data and associated metadata. The field must be defined on the
@@ -99,6 +465,17 @@ class SphBase(eqx.Module):
             time. Default is 0 for all sampling schemes. For healpix
             sampling, setting niter=3 improves accuracy but
             significantly increases JIT compile time.
+        engine : {"s2fft", "dense"}
+            Spherical harmonic transform engine. The default ``"s2fft"``
+            preserves the existing matrix-free behavior. ``"dense"`` builds
+            and caches an exact transform matrix for fast repeated low-lmax
+            transforms.
+        lmax : int or None
+            Maximum spherical harmonic degree. For HEALPix data this may be
+            set below the default ``2 * nside`` to reduce transform work and
+            dense-matrix storage. Other samplings determine their band-limit
+            from the input grid and do not support an override. Default is
+            None.
 
         Raises
         ------
@@ -107,6 +484,12 @@ class SphBase(eqx.Module):
             `data` is not valid for healpix sampling.
 
         """
+        if engine not in {"s2fft", "dense"}:
+            raise ValueError(
+                f"Unsupported SHT engine {engine!r}. Supported engines are "
+                "{'s2fft', 'dense'}."
+            )
+
         self.data = jnp.asarray(data)
         self.freqs = jnp.atleast_1d(freqs)
 
@@ -119,15 +502,61 @@ class SphBase(eqx.Module):
                 )
 
         self._niter = niter
+        self._engine = engine
 
         self.sampling = sampling
-        self.lmax = utils.lmax_from_ntheta(self.data.shape[1], self.sampling)
+        inferred_lmax = utils.lmax_from_ntheta(
+            self.data.shape[1], self.sampling
+        )
+        if lmax is None:
+            self.lmax = inferred_lmax
+        else:
+            lmax = int(lmax)
+            if lmax < 0:
+                raise ValueError("lmax must be non-negative")
+            if self.sampling != "healpix" and lmax != inferred_lmax:
+                raise ValueError(
+                    "An explicit lmax different from the grid band-limit is "
+                    "only supported for HEALPix sampling."
+                )
+            self.lmax = lmax
         self._L = self.lmax + 1  # for s2fft, L = lmax + 1
 
         if self.sampling == "healpix":
             self.nside = utils.hp_npix2nside(self.data.shape[1])
         else:
             self.nside = None
+
+        if self._engine == "dense":
+            if isinstance(self.data, jax.core.Tracer):
+                key = _dense_matrix_key(
+                    self.data.shape[1:],
+                    self.lmax,
+                    self.sampling,
+                    self.nside,
+                    self._niter,
+                    self.data.dtype,
+                )
+                with _DENSE_MATRIX_CACHE_LOCK:
+                    self._dense_matrix = _DENSE_MATRIX_CACHE.get(key)
+                if self._dense_matrix is None:
+                    raise RuntimeError(
+                        "The dense SHT matrix must be precomputed before a "
+                        "dense SphBase object is constructed inside jax.jit. "
+                        "Call precompute_dense_matrix(...) once outside "
+                        "jax.jit."
+                    )
+            else:
+                self._dense_matrix = precompute_dense_matrix(
+                    self.data.shape[1:],
+                    self.lmax,
+                    self.sampling,
+                    nside=self.nside,
+                    niter=self._niter,
+                    dtype=self.data.dtype,
+                )
+        else:
+            self._dense_matrix = None
 
         self.phi = utils.generate_phi(
             lmax=self.lmax, sampling=self.sampling, nside=self.nside

--- a/tests/test_sky.py
+++ b/tests/test_sky.py
@@ -65,6 +65,37 @@ def test_sky_alm_monopole_uniform():
     assert jnp.isclose(alm[0, l_ix, m_ix].real, _T_SKY / Y00, rtol=1e-3)
 
 
+def test_sky_dense_engine_matches_s2fft():
+    """Sky should carry its precomputed dense matrix through jax.jit."""
+    nside = 2
+    lmax = 3
+    data = jnp.asarray(rng.standard_normal((2, 12 * nside**2)))
+    freqs = jnp.array([50.0, 100.0])
+
+    expected = Sky(
+        data,
+        freqs,
+        coord="mepa",
+        niter=1,
+        engine="s2fft",
+        lmax=lmax,
+    ).compute_alm()
+    sky = Sky(
+        data,
+        freqs,
+        coord="mepa",
+        niter=1,
+        engine="dense",
+        lmax=lmax,
+    )
+    actual = sky.compute_alm()
+
+    assert sky.engine == "dense"
+    assert sky.lmax == lmax
+    assert sky._dense_matrix.shape == (10, 48)
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
 # ---------------------------------------------------------------------------
 # compute_alm_eq – rotation to equatorial / mepa
 # ---------------------------------------------------------------------------

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -8,7 +8,12 @@ import s2fft
 
 from croissant import utils
 from croissant.constants import Y00
-from croissant.sphere import SphBase, compute_alm
+from croissant.sphere import (
+    SphBase,
+    clear_dense_matrix_cache,
+    compute_alm,
+    precompute_dense_matrix,
+)
 
 LMAX_PARAMS = [8, 16, 25]
 rng = np.random.default_rng(seed=0)
@@ -200,3 +205,164 @@ def test_compute_alm_monopole(sampling, lmax, disable_jit):
     l_ix, m_ix = utils.getidx(lmax, 0, 0)
     # monopole alm = T / Y00 for a uniform map
     assert jnp.isclose(alm[0, l_ix, m_ix].real, T / Y00, rtol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Dense transform engine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("niter", [0, 1])
+def test_dense_engine_matches_s2fft_healpix(niter):
+    """Dense transforms should reproduce s2fft, including refinement."""
+    nside = 2
+    lmax = 2 * nside
+    data = jnp.asarray(rng.standard_normal((3, 12 * nside**2)))
+
+    expected = compute_alm(
+        data,
+        lmax,
+        "healpix",
+        nside=nside,
+        niter=niter,
+        engine="s2fft",
+    )
+    actual = compute_alm(
+        data,
+        lmax,
+        "healpix",
+        nside=nside,
+        niter=niter,
+        engine="dense",
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_dense_engine_matches_s2fft_equiangular():
+    """Dense transforms should retain support for non-HEALPix samplings."""
+    lmax = 4
+    data = jnp.asarray(rng.standard_normal(_make_data(lmax, "dh", 2).shape))
+
+    expected = compute_alm(data, lmax, "dh", engine="s2fft")
+    actual = compute_alm(data, lmax, "dh", engine="dense")
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_dense_matrix_is_packed_and_cached():
+    """Only independent coefficients are stored and identical keys reuse it."""
+    clear_dense_matrix_cache()
+    matrix1 = precompute_dense_matrix(
+        (48,), 4, "healpix", nside=2, dtype=jnp.float64
+    )
+    matrix2 = precompute_dense_matrix(
+        (48,), 4, "healpix", nside=2, dtype=jnp.float64
+    )
+
+    assert matrix1 is matrix2
+    assert matrix1.shape == (15, 48)
+
+
+def test_dense_engine_is_jittable_after_precompute():
+    """A precomputed matrix can be reused from an enclosing jax.jit."""
+    nside = 2
+    lmax = 4
+    npix = 12 * nside**2
+    data = jnp.asarray(rng.standard_normal((2, npix)))
+    precompute_dense_matrix(
+        (npix,), lmax, "healpix", nside=nside, dtype=data.dtype
+    )
+
+    transform = jax.jit(
+        lambda maps: compute_alm(
+            maps,
+            lmax,
+            "healpix",
+            nside=nside,
+            engine="dense",
+        )
+    )
+
+    expected = compute_alm(data, lmax, "healpix", nside=nside, engine="s2fft")
+    np.testing.assert_allclose(
+        transform(data), expected, rtol=1e-12, atol=1e-12
+    )
+
+
+def test_dense_engine_gradient_matches_s2fft():
+    """Dense matrix multiplication should preserve end-to-end gradients."""
+    nside = 2
+    lmax = 4
+    data = jnp.asarray(rng.standard_normal((2, 12 * nside**2)))
+
+    # Warm the cache before tracing, as production SphBase objects do.
+    compute_alm(
+        data, lmax, "healpix", nside=nside, engine="dense"
+    ).block_until_ready()
+
+    def loss(maps, engine):
+        alm = compute_alm(maps, lmax, "healpix", nside=nside, engine=engine)
+        return jnp.sum(jnp.abs(alm) ** 2)
+
+    expected = jax.grad(loss)(data, "s2fft")
+    actual = jax.grad(loss)(data, "dense")
+    np.testing.assert_allclose(actual, expected, rtol=1e-11, atol=1e-11)
+
+
+def test_sphbase_dense_engine_precomputes_matrix():
+    """SphBase should make dense transforms safe inside jitted methods."""
+    data = jnp.asarray(rng.standard_normal((1, 48)))
+    obj = SphBase(data, jnp.array([50.0]), "healpix", engine="dense")
+
+    assert obj.engine == "dense"
+    assert obj._dense_matrix.shape == (15, 48)
+
+
+def test_invalid_sht_engine():
+    """Unknown engine names should fail before any matrix construction."""
+    with pytest.raises(ValueError, match="Unsupported SHT engine"):
+        SphBase(jnp.ones((1, 48)), [50.0], "healpix", engine="unknown")
+
+
+def test_explicit_lmax_is_healpix_only():
+    """HEALPix can be truncated independently of its pixel resolution."""
+    obj = SphBase(
+        jnp.ones((1, 48)),
+        jnp.array([50.0]),
+        "healpix",
+        lmax=3,
+    )
+    assert obj.lmax == 3
+    assert obj._L == 4
+
+    data = _make_data(4, "dh", 1)
+    with pytest.raises(ValueError, match="only supported for HEALPix"):
+        SphBase(data, jnp.array([50.0]), "dh", lmax=3)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        SphBase(
+            jnp.ones((1, 48)),
+            jnp.array([50.0]),
+            "healpix",
+            lmax=-1,
+        )
+
+
+def test_dense_engine_supports_lmax_below_two_nside():
+    """Dense HEALPix transforms should not inherit s2fft's low-L limit."""
+    nside = 4
+    lmax = 3
+    temperature = 500.0
+    data = temperature * jnp.ones((1, 12 * nside**2))
+
+    alm = compute_alm(
+        data,
+        lmax,
+        "healpix",
+        nside=nside,
+        engine="dense",
+    )
+
+    assert alm.shape == (1, lmax + 1, 2 * lmax + 1)
+    assert jnp.isclose(alm[0, 0, lmax].real, temperature / Y00, rtol=1e-12)

--- a/uv.lock
+++ b/uv.lock
@@ -89,11 +89,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "astropy-iers-data", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pyerfa", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "astropy-iers-data" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pyerfa" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/f8/9c6675ab4c646b95aae2762d108f6be4504033d91bd50da21daa62cab5ce/astropy-6.1.7.tar.gz", hash = "sha256:a405ac186306b6cb152e6df2f7444ab8bd764e4127d7519da1b3ae4dd65357ef", size = 7063411, upload-time = "2024-11-22T21:22:34.373Z" }
 wheels = [
@@ -129,11 +129,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "astropy-iers-data", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pyerfa", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "astropy-iers-data" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pyerfa" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/92/2dce2d48347efc3346d08ca7995b152d242ebd170c571f7c9346468d8427/astropy-7.2.0.tar.gz", hash = "sha256:ae48bc26b1feaeb603cd94bd1fa1aa39137a115fe931b7f13787ab420e8c3070", size = 7057774, upload-time = "2025-11-25T22:36:41.916Z" }
 wheels = [
@@ -374,7 +374,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -425,7 +425,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -531,6 +531,8 @@ dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "s2fft", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "s2fft", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -556,6 +558,7 @@ requires-dist = [
     { name = "lunarsky" },
     { name = "numpy" },
     { name = "s2fft" },
+    { name = "scipy" },
 ]
 
 [package.metadata.requires-dev]
@@ -696,7 +699,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -958,17 +961,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
 wheels = [
@@ -984,17 +987,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -1006,7 +1009,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1050,11 +1053,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.5.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/e5/dabb73ab10330e9535aba14fc668b04a46fcd8e78f06567c4f4f1adce340/jax-0.5.3.tar.gz", hash = "sha256:f17fcb0fd61dc289394af6ce4de2dada2312f2689bb0d73642c6f026a95fbb2c", size = 2072748, upload-time = "2025-03-19T18:23:40.901Z" }
 wheels = [
@@ -1070,11 +1073,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/40/f85d1feadd8f793fc1bfab726272523ef34b27302b55861ea872ec774019/jax-0.9.0.1.tar.gz", hash = "sha256:e395253449d74354fa813ff9e245acb6e42287431d8a01ff33d92e9ee57d36bd", size = 2534795, upload-time = "2026-02-05T18:47:33.088Z" }
 wheels = [
@@ -1089,9 +1092,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/12/b1da8468ad843b30976b0e87c6b344ee621fb75ef8bbd39156a303f59059/jaxlib-0.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:48ff5c89fb8a0fe04d475e9ddc074b4879a91d7ab68a51cec5cd1e87f81e6c47", size = 63694868, upload-time = "2025-03-19T18:23:52.193Z" },
@@ -1117,9 +1120,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/fd/040321b0f4303ec7b558d69488c6130b1697c33d88dab0a0d2ccd2e0817c/jaxlib-0.9.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ff2c550dab210278ed3a3b96454b19108a02e0795625be56dca5a181c9833c9", size = 56092920, upload-time = "2026-02-05T18:46:20.873Z" },
@@ -1140,7 +1143,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "wadler-lindig", marker = "python_full_version < '3.11'" },
+    { name = "wadler-lindig" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/40/a2ea3ce0e3e5f540eb970de7792c90fa58fef1b27d34c83f9fa94fea4729/jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4", size = 45721, upload-time = "2026-01-30T14:18:47.409Z" }
 wheels = [
@@ -1156,7 +1159,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "wadler-lindig", marker = "python_full_version >= '3.11'" },
+    { name = "wadler-lindig" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/be/00294e369938937e31b094437d5ea040e4fd1a20b998ebe572c4a1dcfa68/jaxtyping-0.3.9.tar.gz", hash = "sha256:f8c02d1b623d5f1b6665d4f3ddaec675d70004f16a792102c2fc51264190951d", size = 45857, upload-time = "2026-02-16T10:35:13.263Z" }
 wheels = [
@@ -2419,9 +2422,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jax", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jaxlib", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jax", version = "0.5.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.5.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/16/7c4c54be91fe714598fc1609bf40e94440c9763830ddaa034f6a2989e173/s2fft-1.3.0.tar.gz", hash = "sha256:a174595a79f7a5e2e0186d16d43f39e1d40c09012ad37568a6284245869fb205", size = 22900895, upload-time = "2025-04-25T00:20:40.78Z" }
 wheels = [
@@ -2455,8 +2458,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.9.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/60/ac5914b6a5fce9df03d4c74eeeda9338c83eb3468fd856a08ea998b7656f/s2fft-1.4.0.tar.gz", hash = "sha256:b84c0c2bb0c3dfabe3431360bf90224705554e92966ab87e92affc0fe8f956ba", size = 22770481, upload-time = "2026-02-12T11:11:49.532Z" }
 wheels = [
@@ -2474,7 +2477,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2516,7 +2519,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- add an optional `engine="dense"` transform path for repeated low-band-limit workloads
- generate and cache packed `m >= 0` analysis matrices, then apply them with native JAX matrix multiplication
- preserve JIT compilation, batching, reverse-mode differentiation, and finite `niter` refinement
- allow HEALPix `Beam` and `Sky` objects to select an explicit `lmax` below the default `2 * nside`
- expose matrix precomputation and cache-clearing helpers and document the new API

The existing `engine="s2fft"` behavior remains the default. The dense engine does not add an Almond, CuPy, callback, or JAXbind dependency.

For the motivating `nside=32, lmax=30` case, the packed complex128 matrix has shape `(496, 12288)` and occupies exactly 93 MiB. It built in about 1.44 seconds in a CPU-only local environment.

## Validation

- `uv run pytest -q` — 441 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- dense/s2fft equivalence through `niter=3` at approximately `1e-15` where both engines support the geometry
- gradient, enclosing-JIT, cache reuse, non-HEALPix compatibility, and low-`L`/high-`nside` tests included

GPU execution uses native JAX GEMM, but a CUDA-enabled JAX runtime was not available for local benchmarking.